### PR TITLE
tell gcc not to complain about unused main() parameters

### DIFF
--- a/main.c
+++ b/main.c
@@ -614,6 +614,9 @@ run_game(struct Game* g, const char *title) {
 
 int
 main(int argc, char *argv[]) {
+  (void) argc;
+  (void) argv;
+
   const char *TITLE = "PONG";
 
   struct Game game;


### PR DESCRIPTION
README.md says:

> This mode should only complain of the unused parameters in main, which seem to be required by SDL2, for some reason I still don't know.

FYI, here's how you tell gcc not to complain.
